### PR TITLE
Heap fragmentation fix

### DIFF
--- a/Heap/exl_HeapArea.cpp
+++ b/Heap/exl_HeapArea.cpp
@@ -139,7 +139,7 @@ namespace exl {
 				BlockHeader* header = static_cast<BlockHeader*>(p) - 1;
 				if (newSize <= header->Size) {
 					if (header->Size - alignSize >= sizeof(BlockHeader) + AlignAllocSize(1)) {
-						size_t newFreeSize = header->Size - alignSize - sizeof(BlockHeader) - AlignAllocSize(1);
+						size_t newFreeSize = header->Size - alignSize - sizeof(BlockHeader);
 						header->Size = alignSize;
 						BlockHeader* free2 = reinterpret_cast<BlockHeader*>(header->EndAddress());
 						free2->Size = newFreeSize;


### PR DESCRIPTION
This is a fix for the problem described in https://github.com/ds-pokemon-hacking/PMC/issues/3. Free blocks created by realloc were 8 bytes too small, which would stop them from being combined with adjacent blocks in the free list.